### PR TITLE
Fix _perform_command call in reset_energy function

### DIFF
--- a/pzem/pzem.py
+++ b/pzem/pzem.py
@@ -49,7 +49,7 @@ class PZEM_016(minimalmodbus.Instrument):
                 "address": (2, None, 0, 6),
             },
             "reset_energy": {
-                "address": (66, ""),
+                "address": (66, b""),
             },
         }
 
@@ -138,7 +138,7 @@ class PZEM_016(minimalmodbus.Instrument):
 
     def reset_energy(self) -> bool:
         try:
-            self._performCommand(*self.registers["reset_energy"]["address"])
+            self._perform_command(*self.registers["reset_energy"]["address"])
 
             return True
         except Exception:


### PR DESCRIPTION
`minimalmodbus.Instrument` doesn't contain a definition for `_performCommand(int, string)` but does have a definition for `_perform_command(int, bytes)` - assuming this was a typo.

After making the fix, calling `reset_energy()` appears to correctly reset the energy register in my PZEM-016.

Thanks for the code :)